### PR TITLE
Adding functionality to lock the zoom level

### DIFF
--- a/apps/examples/src/examples/camera-options/CameraOptionsExample.tsx
+++ b/apps/examples/src/examples/camera-options/CameraOptionsExample.tsx
@@ -13,6 +13,7 @@ import 'tldraw/tldraw.css'
 
 const CAMERA_OPTIONS: TLCameraOptions = {
 	isLocked: false,
+	isZoomLocked: false,
 	wheelBehavior: 'pan',
 	panSpeed: 1,
 	zoomSpeed: 1,

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -4,6 +4,7 @@ import { EASINGS } from './primitives/easings'
 /** @internal */
 export const DEFAULT_CAMERA_OPTIONS: TLCameraOptions = {
 	isLocked: false,
+	isZoomLocked: false,
 	wheelBehavior: 'pan',
 	panSpeed: 1,
 	zoomSpeed: 1,

--- a/packages/editor/src/lib/editor/types/misc-types.ts
+++ b/packages/editor/src/lib/editor/types/misc-types.ts
@@ -46,6 +46,8 @@ export interface TLCameraMoveOptions {
 export interface TLCameraOptions {
 	/** Whether the camera is locked. */
 	isLocked: boolean
+	/** Whether the camera's zoom is locked. */
+	isZoomLocked: boolean
 	/** The speed of a scroll wheel / trackpad pan. Default is 1. */
 	panSpeed: number
 	/** The speed of a scroll wheel / trackpad zoom. Default is 1. */

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1104,6 +1104,15 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				},
 			},
 			{
+				id: 'toggle-zoom',
+				kbd: '$L',
+				readonlyOk: true,
+				onSelect(source) {
+					trackEvent('toggle-zoom', { source })
+					editor.toggleZoom()
+				},
+			},
+			{
 				id: 'toggle-snap-mode',
 				label: {
 					default: 'action.toggle-snap-mode',

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -76,6 +76,7 @@ export interface TLUiEventMap {
 	'reset-zoom': null
 	'zoom-into-view': null
 	'zoom-to-content': null
+	'toggle-zoom': null
 	'open-menu': { id: string }
 	'close-menu': { id: string }
 	'create-new-project': null


### PR DESCRIPTION
Adds functionality to allow the user to lock the current zoom level. Currently missing the frontend menu item, but the user can activate the feature via `Ctrl + L`.  Resolves https://github.com/tldraw/tldraw/issues/4531. Requires follow ups by @jankrom (frontend changes) and @ timothywang03 (testing)

https://github.com/user-attachments/assets/8c3f1b2b-1523-456e-9f0e-a03baba433ae


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Test that the user cannot change the Zoom level via pinching nor with the `+` and `-` Zoom buttons when the zoom lock is enabled, and that zoom works normally (passes existing tests) when the zoom lock is not enabled. 

1. `Ctrl + L`
2. Test panning works normally
3. Test that zoom no longer works. 

- [ ] Unit tests
- [ ] End to end tests
