### PR TITLE
Tests for single-finger panning in pen mode

### DIFF
--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -7,9 +7,51 @@ beforeEach(() => {
 	editor = new TestEditor()
 })
 
-it('ignores touch events while in pen mode', async () => {
+it('Pen mode left click on mouse should draw', async () => {
 	editor.setCurrentTool('draw')
 	editor.updateInstanceState({ isPenMode: true })
+	editor.dispatch({
+		type: 'pointer',
+		name: 'pointer_down',
+		isPen: true,
+		pointerId: 1,
+		point: new Vec(100, 100),
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		button: 0,
+		target: 'canvas',
+	})
+
+	expect(editor.getCurrentPageShapes().length).toBe(1)
+})
+
+it('Touch events do not draw in pen mode', async () => {
+	editor.setCurrentTool('draw')
+	editor.updateInstanceState({ isPenMode: true })
+	editor.dispatch({
+		type: 'pointer',
+		name: 'pointer_down',
+		isPen: false,
+		pointerId: 1,
+		point: new Vec(100, 100),
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		button: 0,
+		target: 'canvas',
+	})
+
+	expect(editor.getCurrentPageShapes().length).toBe(0)
+})
+
+it('Touch events do not draw when pen mode is disabled', async () => {
+	editor.setCurrentTool('draw')
+	editor.updateInstanceState({ isPenMode: false })
 	editor.dispatch({
 		type: 'pointer',
 		name: 'pointer_down',
@@ -26,4 +68,18 @@ it('ignores touch events while in pen mode', async () => {
 	})
 
 	expect(editor.getCurrentPageShapes().length).toBe(0)
+})
+
+it('Allows panning with finger in pen mode', () => {
+	editor.updateInstanceState({ isPenMode: true })
+	editor.pointerDown(0, 0, { isPen: false, button: 0 })
+	editor.pointerMove(100, 100)
+	editor.expectCameraToBe(100, 100, 1)
+})
+
+it('Ensure pen does not pan when drawing', () => {
+	editor.updateInstanceState({ isPenMode: true })
+	editor.pointerDown(0, 0, { isPen: true, button: 0 })
+	editor.pointerMove(100, 100)
+	editor.expectCameraToBe(0, 0, 1)
 })

--- a/packages/tldraw/src/test/middleMouseButtonPanning.test.ts
+++ b/packages/tldraw/src/test/middleMouseButtonPanning.test.ts
@@ -29,3 +29,30 @@ it('When clicking the middle mouse button and dragging on a shape, it pans the c
 	editor.pointerMove(100, 100)
 	editor.expectCameraToBe(100, 100, 1)
 })
+
+describe('Middle mouse functions in pen mode', () => {
+	it('Middle mouse button panning works in pen mode', () => {
+		editor.updateInstanceState({ isPenMode: true })
+		editor.pointerDown(0, 0, { button: 1 })
+		editor.pointerMove(100, 100)
+		editor.expectCameraToBe(100, 100, 1)
+	})
+
+	it('When clicking the middle mouse button and dragging on a shape, it pans the camera in pen mode', () => {
+		editor.updateInstanceState({ isPenMode: true })
+		editor.createShapes([
+			{
+				id: createShapeId(),
+				type: 'geo',
+				props: {
+					geo: 'rectangle',
+					w: 100,
+					h: 100,
+				},
+			},
+		])
+		editor.pointerDown(0, 0, { button: 1 })
+		editor.pointerMove(100, 100)
+		editor.expectCameraToBe(100, 100, 1)
+	})
+})

--- a/packages/tldraw/src/test/spacebarPanning.test.ts
+++ b/packages/tldraw/src/test/spacebarPanning.test.ts
@@ -62,3 +62,29 @@ it('When holding spacebar, pressing the arrow keys moves over by one viewport', 
 	expect(editor.getViewportPageBounds()).toEqual({ x: 1080, y: 720, w: 1080, h: 720 })
 	editor.keyUp(' ')
 })
+
+describe('Spacebar functions in pen mode', () => {
+	it('Spacebar panning works in pen mode', () => {
+		editor.updateInstanceState({ isPenMode: true })
+		editor.keyDown(' ')
+		editor.pointerDown(0, 0, { button: 0 })
+		editor.pointerMove(100, 100)
+		editor.expectCameraToBe(100, 100, 1)
+		editor.keyUp(' ')
+	})
+
+	it('When holding spacebar, pressing the arrow keys moves over by one viewport', () => {
+		editor.updateInstanceState({ isPenMode: true })
+		editor.keyDown(' ')
+		editor.expectCameraToBe(0, 0, 1)
+		editor.user.updateUserPreferences({ animationSpeed: 0 })
+		expect(editor.getViewportPageBounds()).toEqual({ x: -0, y: -0, w: 1080, h: 720 })
+		editor.keyDown('ArrowRight')
+		editor.keyUp('ArrowRight')
+		expect(editor.getViewportPageBounds()).toEqual({ x: 1080, y: 0, w: 1080, h: 720 })
+		editor.keyDown('ArrowDown')
+		editor.keyUp('ArrowDown')
+		expect(editor.getViewportPageBounds()).toEqual({ x: 1080, y: 720, w: 1080, h: 720 })
+		editor.keyUp(' ')
+	})
+})


### PR DESCRIPTION
Created unit tests to ensure that when pen mode is active, there is single-finger panning functionality that does not affect spacebar panning or middle mouse button panning.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan
Test that when the user uses the pen function, they can also drag a single finger to pan along the canvas. Also tested that spacebar panning, middle mouse button panning, and eraser functions work as normal (pass existing tests). Added additional tests to each to ensure that when pen mode is activated, it does not affect their functionality. 

- [x] Unit tests
- [ ] End to end tests
